### PR TITLE
FIX: Strip space from filenames on upload

### DIFF
--- a/routes/upload.js
+++ b/routes/upload.js
@@ -23,7 +23,8 @@ router.post('/', function (req, res) {
                 req.pipe(req.busboy);
                 req.busboy.on('file', function (fieldname, file, filename) {
                     filename = filename.toLowerCase();
-                    filename = filename.replace(" ", "-");
+                    fileArr = filename.split(" ");
+                    filename = fileArr.join("-");
                     console.log("Uploading: " + filename);
                     const fstream = fs.createWriteStream(path.join(uploadPath, filename));
                     file.pipe(fstream);

--- a/routes/upload.js
+++ b/routes/upload.js
@@ -23,8 +23,7 @@ router.post('/', function (req, res) {
                 req.pipe(req.busboy);
                 req.busboy.on('file', function (fieldname, file, filename) {
                     filename = filename.toLowerCase();
-                    fileArr = filename.split(" ");
-                    filename = fileArr.join("-");
+                    filename = filename.split(" ").join("-");
                     console.log("Uploading: " + filename);
                     const fstream = fs.createWriteStream(path.join(uploadPath, filename));
                     file.pipe(fstream);


### PR DESCRIPTION
Rather than regexing a replace I thought it more appropriate to use a split to array and join back to string