### PR TITLE
FIX: Frozen Class on Body

### DIFF
--- a/views/preview.html
+++ b/views/preview.html
@@ -49,7 +49,7 @@
     </script>
   </head>
 
-  <body class="longform" name="top">
+  <body class="longform frozen" name="top">
     <div id="loading_overlay" class="loading" {{#meta}}{{#site_img}} style="background-image:url('{{site_img}}');background-position:center center;background-size:cover;" {{/site_img}}{{/meta}}>
       <div class="opacity-pane"></div>
 


### PR DESCRIPTION
Somewhere a while ago there we lost the frozen class on the body which prevented users from scrolling down the page and triggering media by accident