### PR TITLE
FIX: Title Alignment

### DIFF
--- a/views/partials/videobackground.html
+++ b/views/partials/videobackground.html
@@ -17,7 +17,7 @@
     {{/backgroundprops}}
     <div class="col-xs-12 col-sm-10 col-md-8 col-lg-6">
       <div class="row">
-        <div class="{{#format}}{{#fullpage}}header-fullpage{{/fullpage}}{{/format}}">
+        <div class="col-sm-12 {{#format}}{{#fullpage}}header-fullpage{{/fullpage}}{{/format}}">
           <div class="middle">
             {{#title}}
               <h1>{{title}}</h1>

--- a/views/preview.html
+++ b/views/preview.html
@@ -332,7 +332,7 @@
             <div class="content container-fluid">
 
                   <div class="row">
-                    <div class="{{#format}}{{#fullpage}}header-fullpage{{/fullpage}}{{/format}}">
+                    <div class="col-sm-12 {{#format}}{{#fullpage}}header-fullpage{{/fullpage}}{{/format}}">
                       <div class="middle">
                         {{#title}}
                           <h1>{{{title}}}</h1>


### PR DESCRIPTION
Somehow the video background title was centre aligned by default when it should have been left aligned. Class readded.