### PR TITLE
FIX: Confusing Legends

### DIFF
--- a/views/editor/pages/videobackground.html
+++ b/views/editor/pages/videobackground.html
@@ -17,6 +17,7 @@
     </fieldset>
 
     <fieldset>
+      <legend>Offset Portrait Video</legend>
       {{> offset}}
     </fieldset>
 

--- a/views/editor/pages/videofullpage.html
+++ b/views/editor/pages/videofullpage.html
@@ -12,6 +12,7 @@
     </fieldset>
 
     <fieldset>
+      <legend>Offset Portrait Video</legend>
       {{> offset}}
     </fieldset>
 


### PR DESCRIPTION
Have altered the legends for the video background and video fullpage editor pages so that there's no confusion when using the portrait offset functionality