### PR TITLE
fixes LICENSE.md link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You don’t have to know how to code in order to use Mural. But if you do know h
 
 Funding for Mural was provided in Round 3 of Google’s Digital News Initiative Prototype Fund.
 
-Mural is released as open source under the GNU Affero General Public License. See the [LICENSE.md](../blob/master/LICENSE.md) file for the text of the license.
+Mural is released as open source under the GNU Affero General Public License. See the [LICENSE.md](../main/LICENSE.md) file for the text of the license.
 
 Mural is written in NodeJS and uses Electron.
 


### PR DESCRIPTION
I fixed a broken link in README.md for LICENSE.md, appears this links to a branch (master) which no longer exists.