### PR TITLE
Rewrote text in DialogContent.tsx

### DIFF
--- a/src/components/Dialog/dialogs/PaymentSettings/DialogContent.tsx
+++ b/src/components/Dialog/dialogs/PaymentSettings/DialogContent.tsx
@@ -93,14 +93,16 @@ export default function PaymentSettingsDialogContent({
           />
         </Box>
         <Typography variant="h3" color="textSecondary" gutterBottom>
-          Live Payment
+          Web Monetization Live Payment
         </Typography>
         <Typography gutterBottom>
-          To receive live payments while a viewer engages with your content,
-          please add your walletʼ s information below. To split payments between
-          multiple pointers, add additional pointers below and indicate the
-          percentage of payments (out of 100) to be received by each pointer.
-          Please note that Mural received 10% of all payments.
+          To receive web monetization live payments while a viewer engages with your content,
+          please add your payment pointer information below. To split payments between
+          multiple payment pointers, add them below and indicate the percentage of payments
+          (out of 100) to be received by each pointer.
+          Please note that Mural receives 10% of all web monetization payments. This helps
+          us maintain the software and related services. To find out more about Coil's
+          web monetization service, please visit the link below.
         </Typography>
         <Box my={4}>
           {fields.map((field, index) => (
@@ -189,14 +191,16 @@ export default function PaymentSettingsDialogContent({
         </Box>
 
         <Typography gutterBottom>
-          If you donʼt currently have a wallet, you can set one up quickly and
-          easily. First, please set up your account on Coil. Then fetch your
-          Payment Pointer.
+          If you donʼt currently have an online wallet that supports
+          interledger protocol (ILP), you can set one up quickly and
+          easily by creating an account on a service that supports
+          ILP-enabled wallets like Uphold or Gatehub. Then copy your
+          ILP payment pointer here.
         </Typography>
         <Box my={4}>
           <Box mr={10} component="span">
-            <Link target="_blank" href="https://coil.com/">
-              Set Up Coil
+            <Link target="_blank" href="https://coil.com/learn-more">
+              Learn more about Coil
             </Link>
           </Box>
           <Link
@@ -213,10 +217,10 @@ export default function PaymentSettingsDialogContent({
             Access Code
           </Typography>
           <Typography gutterBottom>
-            Create a unique code below (12-15 characters) to allow subscribers
-            from your donation and subscription services (Patreon, Ko-Fi,
-            PayPal, etc.) to access paid content. You can share this code with
-            your funders and subscribers on these services, or by email.
+            Create a unique code below (12-15 characters) to allow your
+            supporters on donation and subscription services (Patreon, Ko-Fi,
+            PayPal, etc.) to access exclusive content. You can share this
+            code with your supporters on these services, or by email.
           </Typography>
         </Box>
         <Box my={4}>


### PR DESCRIPTION
Rewrote text for payment menu on wallets and ILP. The text may be longer than before, so I don't know if this is going to break the design of the menu. If it's too long, let me know and I'll shorten it.

I also changed the Coil link to point to this page, which does a better job of explaining how Coil works: https://coil.com/learn-more