### PR TITLE
Fix: Video Poster Error - Feature: Hide Page Elements Until Load Assets Finished

### DIFF
--- a/electron/exportFrontend/preview.html
+++ b/electron/exportFrontend/preview.html
@@ -131,14 +131,57 @@
           window.loadExclusives();
         })
       }
-
     });
   </script>
     {{/payment}}
   {{/payment.enabled}}
+  <style>
+    body.loading {
+      display: none;
+    }
+    {{#meta}}
+    {{#font_base_rules}}
+    /* Set a font for the main article - focus on readability. */
+    body,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    .slideshow,
+    .slideshow-horizontal {
+      {{{font_base_rules}}}
+    }
+
+    {{/font_base_rules}}
+
+    {{#font_headers_rules}}
+
+    /* Set a special font just for item headers. */
+    .header h1,
+    .header h2,
+    .header-fullpage h1,
+    .header-fullpage h2,
+    header {
+      {{{font_headers_rules}}}
+    }
+
+    {{/font_headers_rules}}
+
+    {{/meta}}
+  </style>
+
+  {{#meta}}
+  {{#custom_css}}
+  <style>
+    {{{custom_css}}}
+  </style>
+  {{/custom_css}}
+  {{/meta}}
 </head>
 
-<body class="longform frozen" name="top">
+<body class="longform frozen loading" name="top">
   <div id="loading_overlay" class="loading" {{#meta}}{{#splash_screen_img}}
     style="background-image:url('{{splash_screen_img}}');background-position:center center;background-size:cover;"
     {{/splash_screen_img}}{{/meta}}>
@@ -591,47 +634,11 @@
   <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
   <!-- <script>Hls = {}; // remove me if you use the script above.</script> -->
   <script type="text/javascript" src="./bundle.js"></script>
-  <style>
-    {{#meta}}
-    {{#font_base_rules}}
-    /* Set a font for the main article - focus on readability. */
-    body,
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6,
-    .slideshow,
-    .slideshow-horizontal {
-      {{{font_base_rules}}}
-    }
-
-    {{/font_base_rules}}
-
-    {{#font_headers_rules}}
-
-    /* Set a special font just for item headers. */
-    .header h1,
-    .header h2,
-    .header-fullpage h1,
-    .header-fullpage h2,
-    header {
-      {{{font_headers_rules}}}
-    }
-
-    {{/font_headers_rules}}
-
-    {{/meta}}
-  </style>
-
-  {{#meta}}
-  {{#custom_css}}
-  <style>
-    {{{custom_css}}}
-  </style>
-  {{/custom_css}}
-  {{/meta}}
+  <script>
+    window.addEventListener('load', () => {
+      $('body').removeClass('loading');
+    })
+  </script>
 
 </body>
 

--- a/frontend-assets/js/media/video.js
+++ b/frontend-assets/js/media/video.js
@@ -56,7 +56,9 @@ function fixBackgroundVideo($el) {
 
 function prepareVideo(scrollStory, $el, id, srcs, attrs) {
   let video = scrollStory.MURAL_VIDEO[id]
-  video.poster = attrs.poster
+  if (attrs.poster) {
+    video.poster = attrs.poster
+  }
   video.muted = attrs.muted
   video.preload = 'auto'
   video.setAttribute('webkit-playsinline', '')

--- a/frontend-assets/js/story.js
+++ b/frontend-assets/js/story.js
@@ -217,7 +217,7 @@ function setItemStart(item) {
 
 function setItemStop(item) {
   if (item.data && item.data.youtubeId) {
-    youtubeMedia.remove(item)
+    // youtubeMedia.remove(item)
   }
 
   if (item.data && item.data.vimeoVideoId) {


### PR DESCRIPTION
Moved preview CSS to head of the document so that it loads before the content.

Added class to hide all body content which is then removed when the body has loaded at which point the story elements have attached to their intended styles.

Check to see if the video being loaded has a poster in the data object before trying to fill it as it fires an error otherwise.