### PR TITLE
Fix: Paywall and Play Pane Styling

### DIFF
--- a/frontend-assets/css/style.scss
+++ b/frontend-assets/css/style.scss
@@ -2784,7 +2784,7 @@ article .part.box_text p {
   width: 100vw;
   height: 100vh;
   display: grid;
-  grid-template-rows: auto;
+  grid-template-rows: none;
   grid-template-areas:
     'intro'
     '.'
@@ -2802,7 +2802,7 @@ article .part.box_text p {
 .loading .logo {
   align-items: center;
   grid-area: logo;
-  max-height: 25vh;
+  max-height: 20vh;
 }
 
 .loading .intro {
@@ -2824,7 +2824,6 @@ article .part.box_text p {
   align-items: center;
   display: flex;
   grid-area: storyname;
-  height: 150px;
   justify-content: center;
 }
 
@@ -2893,7 +2892,10 @@ article .part.box_text p {
   display: none;
   pointer-events: all;
   text-align: center;
-  width: 100vw;
+  width: 100%;
+  img {
+    width: 150px;
+  }
   form {
     input {
       color: #000;


### PR DESCRIPTION
Paywall is now 100% width and not 100vw - image covers the entire element regardless.

Play page reflows a little better now so that on mobile the play button remains on stage at all times.