### PR TITLE
Fix: Audio Path Location

### DIFF
--- a/src/hooks/usePreview.ts
+++ b/src/hooks/usePreview.ts
@@ -54,7 +54,7 @@ export default function usePreview() {
                   audio: item.audio
                     ? {
                         loop: !!item.loop,
-                        mp3: media(item.audio.path),
+                        mp3: item.audio.path,
                         // ogg: string
                         audio_credits: convertToHtml(item.audioCredits),
                       }


### PR DESCRIPTION
MP3 filepaths were only correct for backgroundImage and not for image Audio elements types.